### PR TITLE
Update User Guide

### DIFF
--- a/src/test/data/JsonSerializableAddressBookTest/typicalCompaniesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalCompaniesAddressBook.json
@@ -31,7 +31,7 @@
     "address" : "10 Enterprise Road",
     "tags" : [ "supplier" ],
     "remark" : "Supplier of high-quality raw materials.",
-    "status" : "in-process"
+    "status" : "hr-interview"
   }, {
     "name" : "Elite Manufacturing",
     "phone" : "9482224",

--- a/src/test/java/seedu/address/testutil/TypicalCompanies.java
+++ b/src/test/java/seedu/address/testutil/TypicalCompanies.java
@@ -44,7 +44,7 @@ public class TypicalCompanies {
     public static final Company DELTA = new CompanyBuilder().withName("Delta Enterprises").withPhone("87652533")
             .withEmail("contact@delta.com").withAddress("10 Enterprise Road").withTags("supplier")
             .withRemark("Supplier of high-quality raw materials.")
-            .withStatus("in-process").build();
+            .withStatus("hr-interview").build();
     public static final Company ELITE = new CompanyBuilder().withName("Elite Manufacturing").withPhone("9482224")
             .withEmail("enquiry@elite.com").withAddress("50 Michigan Avenue")
             .withRemark("Known for precision engineering.")


### PR DESCRIPTION
Summary

Update the User Guide to reflect our pivot from “Address Book (AB3)” to Application Tracker (Cerebro) and the latest command behaviours.

What changed
	•	Product terminology: “Address Book” → Application Tracker / Cerebro; “contact/person” → company/application.
	•	Commands
	•	delete: now supports single or comma-separated indices (e.g. delete 3 or delete 1, 4, 9).
	•	edit: accepts one or many indices (comma-separated); applies provided fields to each targeted company; tag edits replace existing tags.
	•	add: documented with remark r/ (and defaulting behaviour); examples updated.
New features documented:
	•	status (basic section added)
	•	remark (section added)
	•	filter (placeholder/coming soon)
	•	Command summary: refreshed to match the above (delete/edit multi-index, add with r/, new commands listed).
	•	Quick Start: minor copy edits to reference Cerebro and current examples.

Notes
	•	This PR is documentation-focused; no functional changes in this diff.
	•	Follow-up issues will add screenshots/snippets for new commands where needed.

Checklist
	•	Terminology updated (AB3 → Application Tracker/Cerebro)
	•	delete multi-index documented
	•	edit multi-index documented
	•	add includes r/ example
	•	status, filter, remark sections present
	•	Command summary consistent with features
