### PR TITLE
Fix AB3 Help Window Bonanza Issue

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -137,12 +137,17 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Opens the help window or focuses on it if it's already opened.
+     * If the help window is minimized, it will be restored and brought to front.
      */
     @FXML
     public void handleHelp() {
         if (!helpWindow.isShowing()) {
             helpWindow.show();
         } else {
+            // Check if the window is minimized (iconified)
+            if (helpWindow.getRoot().isIconified()) {
+                helpWindow.getRoot().setIconified(false);
+            }
             helpWindow.focus();
         }
     }


### PR DESCRIPTION
Previous Issue:
If you minimize the Help Window and then run the help command (or use the Help menu, or the keyboard shortcut F1) again, the original Help Window will remain minimized, and no new Help Window will appear. The remedy is to manually restore the minimized Help Window.

Fixed above issue by checking if help window is in minimized state, and will make minimized state = false, then focus the help window. 

How it works now:
If you minimize the Help Window and then run the help command (or use the Help menu, or the keyboard shortcut F1) again, the original Help Window will pop back up.

**_NOTE:_**
Didnt pass codecov coverage test as this is a GUI feature issue and we do not do GUI testing.
Please help to bypass codecov check and merge PR.
