### PR TITLE
Fix AB3 Help Window Known Issue

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -144,12 +144,20 @@ public class MainWindow extends UiPart<Stage> {
         if (!helpWindow.isShowing()) {
             helpWindow.show();
         } else {
-            // Check if the window is minimized (iconified)
-            if (helpWindow.getRoot().isIconified()) {
-                helpWindow.getRoot().setIconified(false);
-            }
-            helpWindow.focus();
+            // Save current size before restoring (in case it gets corrupted)
+            Stage stage = helpWindow.getRoot();
+            double savedWidth = stage.getWidth();
+            double savedHeight = stage.getHeight();
+
+            // Restore from minimized
+            stage.setIconified(false);
+
+            // Ensure the size is maintained and center it
+            stage.setWidth(savedWidth);
+            stage.setHeight(savedHeight);
+            stage.centerOnScreen();
         }
+        helpWindow.focus();
     }
 
     void show() {


### PR DESCRIPTION
**Problem**
After the previous bug fix that addressed help window not restoring from
minimized state, a new issue emerged where the help window would expand to
full screen when restored from minimized state, instead of maintaining its
intended small popup size.

**After previous big fix 1:**
Help window would restore from minimized state
BUT: Window would expand to full screen instead of staying small

**Current behavior (after this fix):**
Help window restores from minimized state with small popup size (500x180)
Window centers properly on screen

**Root Cause**
When using setIconified(false) to restore a minimized JavaFX window, the
window manager sometimes doesn't preserve the original size constraints,
causing the window to expand to fill available screen space.

**Code Changes/Solution**
Modified HelpWindow constructor to set size constraints
Updated help window restoration logic in MainWindow.handleHelp()
Window now maintains consistent small popup behavior regardless of
minimize/restore cycles