### PR TITLE
Remove tests for placeholder values in AddCommand

### DIFF
--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -152,31 +152,6 @@ public class AddCommandTest {
     }
 
     /**
-     * Tests that adding a company with default placeholder values displays user-friendly text.
-     * Verifies that when optional fields are missing, the system uses placeholder values
-     * that are formatted as "No [field] provided" in the success message.
-     */
-    @Test
-    public void execute_companyWithPlaceholderValues_displaysUserFriendlyText() throws Exception {
-        ModelStubAcceptingCompanyAdded modelStub = new ModelStubAcceptingCompanyAdded();
-        Company companyWithPlaceholders = new CompanyBuilder()
-                .withName("Test Company")
-                .withPhone("000")
-                .withEmail("noemailprovided@placeholder.com")
-                .withAddress("No address provided")
-                .withTags()
-                .withRemark("No remark provided")
-                .build();
-
-        CommandResult commandResult = new AddCommand(companyWithPlaceholders).execute(modelStub);
-
-        String expectedMessage = String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(companyWithPlaceholders));
-        assertTrue(expectedMessage.contains("No phone provided"));
-        assertTrue(expectedMessage.contains("No email provided"));
-        assertEquals(Arrays.asList(companyWithPlaceholders), modelStub.companiesAdded);
-    }
-
-    /**
      * Tests that adding a company with numbers in its name is successful.
      * Company names can contain alphanumeric characters, so names like
      * "3M Corporation" should be valid and successfully added.

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -242,19 +242,4 @@ public class AddCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
     }
 
-    // Test that when only name is provided, other fields get placeholder values
-    @Test
-    public void parse_onlyNameProvided_setsPlaceholderValues() {
-        Company expectedCompany = new CompanyBuilder()
-                .withName(VALID_NAME_BOEING)
-                .withPhone("000")
-                .withEmail("noemailprovided@placeholder.com")
-                .withAddress("No address provided")
-                .withRemark("No remark provided")
-                .withTags()
-                .withStatus("to-apply")
-                .build();
-
-        assertParseSuccess(parser, NAME_DESC_BOEING, new AddCommand(expectedCompany));
-    }
 }


### PR DESCRIPTION
Deleted tests that verify placeholder values are set for missing optional fields in AddCommand and AddCommandParser. We are removing placeholder values in a future PR.