### PR TITLE
Fix no remark add command

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -74,7 +74,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
             remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get());
         } else {
-            remark = new Remark("No remark provided");
+            remark = new Remark(null);
         }
 
         Status status;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -149,6 +149,9 @@ public class ParserUtil {
     public static Remark parseRemark(String remark) throws ParseException {
         requireNonNull(remark);
         String trimmedRemark = remark.trim();
+        if (!Remark.isValidRemark(trimmedRemark)) {
+            throw new ParseException(Remark.MESSAGE_CONSTRAINTS);
+        }
         return new Remark(trimmedRemark);
     }
 

--- a/src/main/java/seedu/address/model/company/Address.java
+++ b/src/main/java/seedu/address/model/company/Address.java
@@ -9,11 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Please add an address!";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Address cannot be empty (only for add command)
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
 

--- a/src/main/java/seedu/address/model/company/Remark.java
+++ b/src/main/java/seedu/address/model/company/Remark.java
@@ -8,10 +8,11 @@ package seedu.address.model.company;
 public class Remark {
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * Remark must not be empty (only for add command)
      */
     public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public static final String MESSAGE_CONSTRAINTS = "Please add a remark!";
 
     public final String value;
 

--- a/src/test/java/seedu/address/testutil/CompanyBuilder.java
+++ b/src/test/java/seedu/address/testutil/CompanyBuilder.java
@@ -19,7 +19,6 @@ import seedu.address.model.util.SampleDataUtil;
 public class CompanyBuilder {
 
     public static final String DEFAULT_NAME = "Test Company";
-    public static final String DEFAULT_REMARK = "No remark provided";
     public static final String DEFAULT_STATUS = "to-apply";
 
     private Name name;
@@ -40,7 +39,7 @@ public class CompanyBuilder {
         email = new Email(null);
         address = new Address(null);
         tags = new HashSet<>();
-        remark = new Remark(DEFAULT_REMARK);
+        remark = new Remark(null);
         status = new Status(DEFAULT_STATUS);
     }
 

--- a/src/test/java/seedu/address/testutil/CompanyUtil.java
+++ b/src/test/java/seedu/address/testutil/CompanyUtil.java
@@ -45,7 +45,9 @@ public class CompanyUtil {
         company.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
-        sb.append(PREFIX_REMARK + company.getRemark().value + " ");
+        if (company.getRemark().value != null) {
+            sb.append(PREFIX_REMARK + company.getAddress().value + " ");
+        }
         sb.append(PREFIX_STATUS + company.getStatus().toUserInputString() + " ");
         return sb.toString();
     }
@@ -77,7 +79,13 @@ public class CompanyUtil {
                 sb.append(PREFIX_ADDRESS).append(" ");
             }
         });
-        descriptor.getRemark().ifPresent(remark -> sb.append(PREFIX_REMARK).append(remark.value).append(" "));
+        descriptor.getRemark().ifPresent(remark -> {
+            if (remark.value != null) {
+                sb.append(PREFIX_REMARK).append(remark.value).append(" ");
+            } else {
+                sb.append(PREFIX_REMARK).append(" ");
+            }
+        });
         descriptor.getStatus().ifPresent(status ->
                 sb.append(PREFIX_STATUS).append(status.toUserInputString()).append(" "));
         if (descriptor.getTags().isPresent()) {


### PR DESCRIPTION
Previous behaviour:
- when remark prefix was not detected, it will initialise to Remark("No Remark Provided"), hence remark was not actually nullable
- add n/Google created a company with a remark "No Remark Provided"
- add n/Google a/ r/ was accepted as it bypassed address and remark parser entirely

Current behaviour:
- changed to Remark(null)
- add n/Google now creates a company with a Remark with a value of null.
- add n/Google a/ r/ is no longer accepted. Edit still works as per normal to clear those fields.

Also fixed other util classes to reflect this change.

To be able to see if remark is actually null, you'll need to merge my string builder pr first :)