### PR TITLE
Remark display fix

### DIFF
--- a/src/main/java/seedu/address/ui/CompanyCard.java
+++ b/src/main/java/seedu/address/ui/CompanyCard.java
@@ -80,7 +80,12 @@ public class CompanyCard extends UiPart<Region> {
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
         fullRemarkText = company.getRemark().value;
-        remark.setText(fullRemarkText);
+        if (fullRemarkText == null) {
+            remark.setVisible(false); // Hides remark if empty
+            remark.setManaged(false); // Truncates company card to not show a blank line
+        } else {
+            remark.setText("Remark: " + fullRemarkText);
+        }
 
         setupExpandableRemark();
     }


### PR DESCRIPTION
Previous behaviour:
- empty line if remark is null
- simply displays remark

Current behaviour:
- Truncates the company card to no longer show any empty lines
- displays "Remark: <REMARK>" if present.

If we do not want to truncate simply remove the remark.setManaged(false) line