### PR TITLE
Fix Transparent Metrics Window in Fullscreen Mode

### DIFF
--- a/src/main/java/seedu/address/ui/MetricsWindow.java
+++ b/src/main/java/seedu/address/ui/MetricsWindow.java
@@ -46,12 +46,6 @@ public class MetricsWindow extends ClosableWindow {
      */
     private void configureWindow() {
         Stage stage = getRoot();
-        stage.setMinWidth(400);
-        stage.setMinHeight(300);
-        stage.setMaxWidth(600);
-        stage.setMaxHeight(500);
-        stage.setWidth(500);
-        stage.setHeight(400);
 
         // Add event handlers to refresh data when window is restored or focused
         stage.iconifiedProperty().addListener((observable, wasIconified, isIconified) -> {

--- a/src/main/resources/view/MetricsWindow.fxml
+++ b/src/main/resources/view/MetricsWindow.fxml
@@ -19,7 +19,7 @@
         <URL value="@MetricsWindow.css" />
       </stylesheets>
 
-      <VBox alignment="CENTER" fx:id="metricsContainer" spacing="10">
+      <VBox alignment="CENTER" fx:id="metricsContainer" spacing="10" minWidth="400" minHeight="300" maxWidth="600" maxHeight="500" prefWidth="500" prefHeight="400">
         <children>
           <VBox fx:id="statusMetrics" spacing="5" styleClass="metrics-content">
             <!-- Status percentages will be populated dynamically -->


### PR DESCRIPTION
Changes:

Added minWidth, maxWidth, prefWidth, and prefHeight to the root VBox in MetricsWindow.fxml.

Removed redundant stage size configuration in MetricsWindow.java.

Previous behavior:
Metrics window opens as a fullscreen with transparent background which users can see their own wallpaper (when in full screen mode), not aligning with help window behavior.

Result:
Metrics window now opens as  a fullscreen with solid background (when in full screen mode), matching Help window behavior.
