### PR TITLE
Add page break after setup section in Developer Guide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -20,7 +20,7 @@ title: Developer Guide
 Refer to the guide [_Setting up and getting started_](SettingUp.md).
 
 --------------------------------------------------------------------------------------------------------------------
-
+<div style="page-break-after: always;"></div>
 ## **Design**
 ### Architecture
 


### PR DESCRIPTION
Inserted a HTML page break after the 'Setting up and getting started' section to improve document formatting.